### PR TITLE
Deprecated KeyboardEvent.keyCode changed to KeyboardEvent.code

### DIFF
--- a/lesson04.html
+++ b/lesson04.html
@@ -27,18 +27,18 @@
     document.addEventListener("keyup", keyUpHandler, false);
 
     function keyDownHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = true;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = true;
         }
     }
     function keyUpHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = false;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = false;
         }
     }

--- a/lesson05.html
+++ b/lesson05.html
@@ -27,18 +27,18 @@
     document.addEventListener("keyup", keyUpHandler, false);
 
     function keyDownHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = true;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = true;
         }
     }
     function keyUpHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = false;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = false;
         }
     }

--- a/lesson06.html
+++ b/lesson06.html
@@ -42,18 +42,18 @@
     document.addEventListener("keyup", keyUpHandler, false);
 
     function keyDownHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = true;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = true;
         }
     }
     function keyUpHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = false;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = false;
         }
     }

--- a/lesson07.html
+++ b/lesson07.html
@@ -42,18 +42,18 @@
     document.addEventListener("keyup", keyUpHandler, false);
 
     function keyDownHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = true;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = true;
         }
     }
     function keyUpHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = false;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = false;
         }
     }

--- a/lesson08.html
+++ b/lesson08.html
@@ -43,18 +43,18 @@
     document.addEventListener("keyup", keyUpHandler, false);
 
     function keyDownHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = true;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = true;
         }
     }
     function keyUpHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = false;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = false;
         }
     }

--- a/lesson09.html
+++ b/lesson09.html
@@ -44,18 +44,18 @@
     document.addEventListener("mousemove", mouseMoveHandler, false);
 
     function keyDownHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = true;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = true;
         }
     }
     function keyUpHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code == 'ArrowRight') {
             rightPressed = false;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = false;
         }
     }

--- a/lesson10.html
+++ b/lesson10.html
@@ -45,18 +45,18 @@
     document.addEventListener("mousemove", mouseMoveHandler, false);
 
     function keyDownHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code  == "ArrowRight") {
             rightPressed = true;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = true;
         }
     }
     function keyUpHandler(e) {
-        if(e.keyCode == 39) {
+        if(e.code == 'ArrowRight') {
             rightPressed = false;
         }
-        else if(e.keyCode == 37) {
+        else if(e.code == 'ArrowLeft') {
             leftPressed = false;
         }
     }


### PR DESCRIPTION
The recommended  `KeyboardEvent.code` is used instead of `KeyboardEvent.keyCode`.

This PR resolves the issue #9. 